### PR TITLE
feat: open classloader (and a few other changes)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,8 @@
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-
 plugins {
     kotlin("jvm") version "2.0.21"
     id("de.eldoria.plugin-yml.paper") version "0.7.1"
     id("xyz.jpenilla.run-paper") version "2.3.1"
-    id("com.github.johnrengelman.shadow") version "8.1.1"
+    id("com.gradleup.shadow") version "8.3.6"
 }
 
 group = "win.templeos.lualink"
@@ -13,25 +11,21 @@ version = "1.0-SNAPSHOT"
 repositories {
     mavenLocal()
     mavenCentral()
-    maven("https://repo.purpurmc.org/snapshots")
+    maven("https://repo.papermc.io/repository/maven-public/")
 }
 
 val luaJavaVersion:String by project
 
 dependencies {
-    testImplementation(kotlin("test"))
-    library(kotlin("stdlib"))
-    api(kotlin("stdlib"))
-    compileOnly("org.purpurmc.purpur:purpur-api:1.21-R0.1-SNAPSHOT")
+    // Kotlin (downloaded and loaded at runtime)
+    paperLibrary(kotlin("stdlib"))
+    // Paper API
+    compileOnly("io.papermc.paper:paper-api:1.20-R0.1-SNAPSHOT")
+    // LuaJava (cannot be easily relocated or downloaded at runtime)
     implementation("party.iroiro.luajava:luajava:4.0.3-SNAPSHOT")
     implementation("party.iroiro.luajava:luajit:$luaJavaVersion")
+    // LuaJava natives (cannot be easily relocated or downloaded at runtime)
     runtimeOnly("party.iroiro.luajava:luajit-platform:$luaJavaVersion:natives-desktop")
-}
-
-tasks.withType<ShadowJar> {
-    dependencies {
-
-    }
 }
 
 paper {
@@ -40,6 +34,9 @@ paper {
     generateLibrariesJson = true
     authors = listOf("Saturn745")
     loader = "win.templeos.lualink.PluginLibrariesLoader"
+    // This allows the plugin to access external plugins' APIs without depending on them.
+    // This may cause conflicts if different versions of the same dependency are loaded by different plugins.
+    hasOpenClassloader = true
 }
 
 tasks {


### PR DESCRIPTION
Changes:
- Opened class loader of the LuaLink plugin, which means script are now able to access APIs other plugins without LuaLink being required to depend on each of them. This may cause conflicts if different versions of the same dependency are loaded by different plugins, but is yet to be confirmed. There are a few solutions to potentially fix it.
- Replaced Purpur dependency with Paper, as LuaLink is not using any features exclusive to Purpur. This **should not** affect scripts that use Purpur API - they should be able to access this API as usual.
- Updated the Shadow plugin, as old version was not compatible with Java 21.
- Kotlin libraries are now downloaded at runtime. Other dependencies must be shaded for now.
- Added a bunch of comments for clarity, let me know if I should remove them.