### PR TITLE
Add support for Teal

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,9 @@ jobs:
       GIT_COMMIT_MESSAGE: ${{ join(github.event.commits.*.message, '<br>') }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          submodules: true
+
       - name: Set up JDK 21
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/main/resources/lua/teal"]
+	path = src/main/resources/lua/teal
+	url = https://github.com/teal-language/tl.git

--- a/src/main/kotlin/win/templeos/lualink/lua/LuaManager.kt
+++ b/src/main/kotlin/win/templeos/lualink/lua/LuaManager.kt
@@ -47,6 +47,7 @@ class LuaManager(private val plugin: LuaLink, luaRuntime: LuaRuntimes) {
         private const val LUA_SCRIPT_CLASS_PATH = "/lua/script.lua"
         private const val LUA_SCRIPT_PATH = "/lua/lualink.lua"
         private const val LUA_SCRIPT_SCHEDULER_PATH = "/lua/scheduler.lua"
+        private const val LUA_SCRIPT_TEAL_PATH = "/lua/teal/tl.lua"
     }
 
     /**
@@ -118,7 +119,7 @@ class LuaManager(private val plugin: LuaLink, luaRuntime: LuaRuntimes) {
             }
 
             // Get all subdirectories in the scripts directory that contain a main.lua file
-            val scriptFolders = scriptsDir.listFiles()?.filter { it.isDirectory && it.resolve("main.lua").exists() }
+            val scriptFolders = scriptsDir.listFiles()?.filter { it.isDirectory && (it.resolve("main.lua").exists() || it.resolve("main.tl").exists()) }
             // Create a table to hold the script names
             lua.newTable()
             // Iterate through the script folders and add their names to the table
@@ -202,6 +203,11 @@ class LuaManager(private val plugin: LuaLink, luaRuntime: LuaRuntimes) {
         val schedulerCode = loadResourceAsStringByteBuffer(LUA_SCRIPT_SCHEDULER_PATH)
         lua.load(schedulerCode, "scheduler.lua")
         lua.pCall(0, 0)
+
+        val tealCode = loadResourceAsStringByteBuffer(LUA_SCRIPT_TEAL_PATH)
+        lua.load(tealCode, "tl.lua")
+        lua.pCall(0, 1)
+        lua.setGlobal("tl")
 
         // Load the script manager implementation from resources
         val scriptManagerCode = loadResourceAsStringByteBuffer(LUA_SCRIPT_MANAGER_PATH)


### PR DESCRIPTION
Adds support for [Teal](https://github.com/teal-language/tl) a typed dialect of Lua. Similar to Typescript but for Lua

Simply make a `main.tl` or require a Teal based module and LuaLink will automatically compile Teal -> Lua before running it


Example
```teal
-- Test Teal features: enums, records, interfaces, type checking

-- Example: Teal interface and enum usage

global enum Color
   "Red"
   "Green"
   "Blue"
end

local interface ColoredShape
   color: Color
   get_color_name: function(self): string
end

local record Box is ColoredShape
   width: number
   height: number
end

function Box:get_color_name(): string
   if self.color == Color.Red then
      return "Red"
   elseif self.color == Color.Green then
      return "Green"
   elseif self.color == Color.Blue then
      return "Blue"
   else
      return "Unknown"
   end
end

local mybox: Box = { color = Color.Green, width = 10, height = 5 }
setmetatable(mybox, { __index = Box })
print("Box color enum:", mybox.color)
print("Box color name:", mybox:get_color_name())
print("Box size:", mybox.width, mybox.height)

local function add(a: number, b: number): number
   return a + b
end

local s = add(1, 2)
print(s)

script:onLoad(function()
   print("Script loaded")
end)
```


Likely needs more testing, stub files (LuaStubGen and make sure that all of it is checked properly at compile time of script. Likely means the stubs are gonna need to be included or perhaps downloaded if Teal is used?), and documentation written (just basic mention that you can use Teal by making your main file a teal file or require one)