### PR TITLE
mark 1.21.6 as supported and adjust dependency resolution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 val buildNum = System.getenv("GITHUB_RUN_NUMBER") ?: "SNAPSHOT"
 
 group = "win.templeos.lualink"
-version = "1.21.5-$buildNum"
+version = "1.21.6-$buildNum"
 
 repositories {
     mavenLocal()
@@ -34,7 +34,7 @@ dependencies {
     // Kotlin (downloaded and loaded at runtime)
     paperLibrary(kotlin("stdlib"))
     // Paper API
-    compileOnly("io.papermc.paper:paper-api:1.20-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.6-R0.1-SNAPSHOT")
     // LuaJava (cannot be easily relocated or downloaded at runtime)
     implementation("party.iroiro.luajava:luajava:$luaJavaVersion") // Use our fork of the LuaJava library
     implementation("party.iroiro.luajava:luajit:$luaJavaVersion")
@@ -64,7 +64,7 @@ modrinth {
     versionNumber.set(version.toString())
     versionType.set("release")
     uploadFile.set(tasks.shadowJar.get())
-    gameVersions.addAll("1.21.4", "1.21.5")
+    gameVersions.addAll("1.21.4", "1.21.5", "1.21.6")
     loaders.addAll("paper", "purpur")
     changelog.set(System.getenv("GIT_COMMIT_MESSAGE"))
 }
@@ -81,7 +81,7 @@ hangarPublish {
         platforms {
             register(Platforms.PAPER) {
                 jar.set(tasks.shadowJar.flatMap { it.archiveFile })
-                platformVersions.set(listOf("1.21.4", "1.21.5"))
+                platformVersions.set(listOf("1.21.4", "1.21.5", "1.21.6"))
             }
         }
     }
@@ -92,7 +92,7 @@ tasks {
         // Configure the Minecraft version for our task.
         // This is the only required configuration besides applying the plugin.
         // Your plugin's jar (or shadowJar if present) will be used automatically.
-        minecraftVersion("1.21.5")
+        minecraftVersion("1.21.6")
 
         // Make sure runServer is ran with -add-opens=java.base/java.util=ALL-UNNAMED
         jvmArgs(

--- a/src/main/kotlin/win/templeos/lualink/lua/LuaCommand.kt
+++ b/src/main/kotlin/win/templeos/lualink/lua/LuaCommand.kt
@@ -29,12 +29,12 @@ class LuaCommand(private val command: LuaValue) : Command(command.get("metadata"
             this.aliases = aliasList.values.map { it.toString() }.toMutableList()
         }
     }
-    override fun execute(sender: CommandSender, commandLabel: String, args: Array<out String>?): Boolean {
+    override fun execute(sender: CommandSender, commandLabel: String, args: Array<out String>): Boolean {
         command.get("handler").call(sender, args)
         return true
     }
 
-    override fun tabComplete(sender: CommandSender, alias: String, args: Array<out String>?): MutableList<String> {
+    override fun tabComplete(sender: CommandSender, alias: String, args: Array<out String>): MutableList<String> {
         val tabCompleteHandler = command.get("metadata").get("tabComplete")
         if (tabCompleteHandler.type() != Lua.LuaType.FUNCTION) {
             // Default behavior: Return online player names
@@ -43,7 +43,7 @@ class LuaCommand(private val command: LuaValue) : Command(command.get("metadata"
         val result = tabCompleteHandler.call(sender, args)[0]
         if (result.type() == Lua.LuaType.TABLE) {
             val list = result.toJavaObject() as HashMap<*, *>
-            return (if (args != null) list.values.filter { it.toString().contains(args.last(), true) } else list.values).toMutableList() as MutableList<String>
+            return (list.values.filter { it.toString().contains(args.last(), true) }).toMutableList() as MutableList<String>
         }
         // Default behavior: Return online player names
         return null!!

--- a/src/main/resources/libraries.json
+++ b/src/main/resources/libraries.json
@@ -1,4 +1,5 @@
 // External libraries to be loaded for use with scripts. Server must be restarted for the changes to take effect.
+// IMPORTANT: If you wish to resolve libraries from Maven Central, you're strongly advised to instead use a mirror.
 {
   "repositories": {
     // "RepositoryName": "https://repo.example.com/releases"


### PR DESCRIPTION
Tested LuaLink on 1.21.6 and as expected, it seems to work perfectly fine. Bumped versions, including Paper API dependency which I will talk about in the next paragraph.

With https://github.com/PaperMC/Paper/pull/12689 being part of Paper now, I had to adjust how we download internal, and user-specified dependencies in the runtime. Paper API version bump was needed in order to use API introduced by mentioned PR. Logic should gracefully fallback to existing methods when needed.

Plugin still works as it used to and no breaking changes were introduced. I tested on 1.20, 1.21.4 and 1.21.6.

LuaCommand changes had to be made in order to make the plugin compilable, but they also seem to be non-breaking and backwards compatible.

Ready for review. I added two commits so you may want to squash before merging.