### PR TITLE
add `exceptionally(try: function, catch: function)` function

### DIFF
--- a/src/main/kotlin/win/templeos/lualink/lua/LuaManager.kt
+++ b/src/main/kotlin/win/templeos/lualink/lua/LuaManager.kt
@@ -249,6 +249,27 @@ class LuaManager(private val plugin: LuaLink, luaRuntime: LuaRuntimes) {
        })
        lua.setGlobal("__synchronized")
 
+       lua.push(JFunction { it ->
+           if (!it.isFunction(-2)) {
+               it.error("First argument must be a Lua function. Syntax: exceptionally(function, function)")
+               return@JFunction 0
+           }
+           if (!it.isFunction(-1)) {
+               it.error("Second argument must be a Lua function. Syntax: exceptionally(function, function)")
+               return@JFunction 0
+           }
+           try {
+               it.pushValue(-2)
+               it.pCall(0, 0)
+           } catch (thr: Throwable) {
+               it.pushValue(-1)
+               it.pushJavaObject(thr)
+               it.pCall(1, 0)
+           }
+           return@JFunction 0
+       })
+        lua.setGlobal("__exceptionally")
+
         // Load the script class
         val scriptCode = loadResourceAsStringByteBuffer(LUA_SCRIPT_CLASS_PATH)
         lua.load(scriptCode, "script.lua")

--- a/src/main/resources/lua/scriptmanager.lua
+++ b/src/main/resources/lua/scriptmanager.lua
@@ -192,7 +192,8 @@ local sharedEnv = {
     -- LuaLink globals
     server = server,
     import = java.import, -- Simple alias for java.import
-    synchronized = __synchronized
+    synchronized = __synchronized,
+    exceptionally = __exceptionally
 }
 
 local globalModuleCache = {} -- Global cache for modules in the libs folder


### PR DESCRIPTION
This PR makes it possible to try...catch Java code from within Lua script. Please review before merging because I'm not 100% sure I did it right.

Will update documentation once this is merged.

### SYNTAX
```lua
function exceptionally(try: function, catch: function)
```

<br>

### TESTING
```lua
local URI = import("java.net.URI")

print("")
print("=== THIS SHOULD THROW ===")
exceptionally(function()
    local uri = URI("invalid uri")
    print("This message will not be printed because line above throws.")
end, function(throwable)
    print(throwable:getClass():getSimpleName() .. ": " .. throwable:getMessage())
end)

print("")
print("=== THIS SHOULD COMPLETE SUCCESSFULLY ===")
exceptionally(function()
    local uri = URI("https://example.com")
    print("This message will be printed because passed value is a correct URI.")
end, function(throwable)
    print(throwable:getClass():getSimpleName() .. ": " .. throwable:getMessage())
    print("This message will not be printed because no exception was thrown in the 'try' function.")
end)

print("")
```
```
[11:31:08 INFO]: [LuaLink/test] Internal onUnload handler called for script: test
[11:31:08 INFO]: [LuaLink/test] 
[11:31:08 INFO]: [LuaLink/test] === THIS SHOULD THROW ===
[11:31:08 INFO]: [LuaLink/test] LuaException: java.net.URISyntaxException: Illegal character in path at index 7: invalid uri
[11:31:08 INFO]: [LuaLink/test] 
[11:31:08 INFO]: [LuaLink/test] === THIS SHOULD COMPLETE SUCCESSFULLY ===
[11:31:08 INFO]: [LuaLink/test] This message will be printed because passed value is a correct URI.
[11:31:08 INFO]: [LuaLink/test] 
[11:31:08 INFO]: [LuaLink/test] Internal onLoad handler called for script: test
```
