### PR TITLE
bump to 1.21.8 and adjust runServer environment

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,7 @@
+plugins {
+    // Required to run 'runServer' task using JetBrains Runtime (for debugging and enhanced hot-swap purposes)
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
+}
+
 rootProject.name = "LuaLink"
 


### PR DESCRIPTION
- Updated version and dependencies to 1.21.8.
- Marked 1.21.8 as supported version on Modrinth and Hangar.
- Added additional flags to the `runServer` task. Including comments that describe what each flag does.
- Made `runServer` task be run using JetBrains Runtime for enhanced hot-swap capabilities. 

I also removed this:
```gradle
tasks.test {
    useJUnitPlatform()
}
```
as plugin don't have any tests configured.